### PR TITLE
(Better) indicators for banned, testing plugins; search improvements; a bug fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,40 +18,42 @@
     </header>
 
     <main>
-        <h2>Available Plugins</h2>
         <section id="available">
+            <h2>Available Plugins</h2>
             <ol class="plugin-list"></ol>
         </section>
 
-        <h2>Outdated Plugins</h2>
         <section id="outdated">
+            <h2>Outdated Plugins</h2>
             <p>These plugins have not been updated by the developer for the current API level. Please be patient while they are being updated!</p>
             <ol class="plugin-list"></ol>
         </section>
 
-        <h2>Adoptable Plugins</h2>
         <section id="adoptable">
+            <h2>Adoptable Plugins</h2>
             <p>These plugins have been abandoned by their original developer. If you're interested in taking over development, please reach out to the developer and let us know on Discord.</p>
             <ol class="plugin-list"></ol>
         </section>
 
-        <h2>Stale Plugins</h2>
         <section id="stale">
+            <h2>Stale Plugins</h2>
             <p>These plugins have not been officially discontinued but have not been updated for the current API level in over six months. The developer remains active in the community. They may be coming back.</p>
             <ol class="plugin-list"></ol>
         </section>
 
-        <h2>Discontinued Plugins</h2>
         <section id="discontinued">
+            <h2>Discontinued Plugins</h2>
             <p>These plugins have been discontinued due to our plugin rules or the developer's discretion. They won't be coming back.</p>
             <ol class="plugin-list"></ol>
         </section>
 
-        <h2>Obsolete Plugins</h2>
         <section id="obsolete">
+            <h2>Obsolete Plugins</h2>
             <p>These plugins are now obsolete and are no longer needed. This can be due to new features added to the game or by being replaced by another plugin. They won't be coming back.</p>
             <ol class="plugin-list"></ol>
         </section>
+
+        <p id="no-plugins-found" class="hidden">No plugins match your search criteria.</p>
     </main>
 
     <script type="module">
@@ -113,10 +115,26 @@
         const isValidPlugin = (plugin) => plugin.DalamudApiLevel >= currentApi - 1 || validNonCurrent.includes(plugin.InternalName);
 
         function createCard(plugin, type) {
-            const card = document.createElement('li');
+            const listElement = document.createElement('li');
+            const card = document.createElement('div');
+            listElement.append(card);
+
+            // class (for label) and visual indicator for testing exclusive plugins
+            if (plugin.IsTestingExclusive) {
+                card.classList.add('testing');
+                const testingIndicator = document.createElement('div');
+                testingIndicator.classList.add('testing-indicator');
+                testingIndicator.title = 'Testing Exclusive';
+                listElement.append(testingIndicator);
+            }
+
+            // ribbon, for categories other than "available" plugins
+            let ribbon;
             if (type) {
-                card.dataset.type = type;
-                card.classList.add('ribbon', type.toLowerCase());
+                ribbon = document.createElement('div');
+                ribbon.classList.add('ribbon', type.toLowerCase());
+                ribbon.innerText = type;
+                card.append(ribbon);
             }
 
             const header = document.createElement('header');
@@ -138,9 +156,6 @@
                 name.append(link);
                 link.href = plugin.RepoUrl;
                 link.innerText = plugin.Name;
-                if (plugin.IsTestingExclusive) {
-                    link.classList.add('testing');
-                }
             } else {
                 name.innerText = plugin.Name;
             }
@@ -165,13 +180,22 @@
             }
 
             // banned plugin indicator
-            if (bannedPlugins.find((p) => p.Name === plugin.InternalName && p.AssemblyVersion === plugin.AssemblyVersion)) {
-                card.classList.add('ribbon', 'banned');
-                card.dataset.type = 'Blocked';
+            const bannedPlugin = bannedPlugins.find((p) => p.Name === plugin.InternalName && p.AssemblyVersion === plugin.AssemblyVersion);
+            if (bannedPlugin) {
                 const e = document.createElement('div');
                 e.innerText = 'Current version can not be installed. Please wait for an update.';
                 e.classList.add('hint');
                 card.append(e);
+
+                if (!ribbon) {
+                    ribbon = document.createElement('div');
+                    card.insertBefore(ribbon, header);
+                }
+                ribbon.classList.add('ribbon', 'banned');
+                ribbon.innerText = 'Blocked';
+                if (bannedPlugin.Reason) {
+                    ribbon.title = bannedPlugin.Reason;
+                }
             }
 
             card.append(attributeElements.Punchline);
@@ -198,35 +222,109 @@
             }
 
             switch (type) {
-                case 'Obsolete':
-                    obsoletePlugins.append(card);
+                case 'Outdated':
+                    outdatedPlugins.append(listElement);
                     break;
 
                 case 'Adoptable':
-                    adoptablePlugins.append(card);
+                    adoptablePlugins.append(listElement);
                     break;
 
                 case 'Stale':
-                    stalePlugins.append(card);
+                    stalePlugins.append(listElement);
                     break;
 
                 case 'Discontinued':
-                    discontinuedPlugins.append(card);
+                    discontinuedPlugins.append(listElement);
                     break;
 
-                case 'Outdated':
-                    outdatedPlugins.append(card);
+                case 'Obsolete':
+                    obsoletePlugins.append(listElement);
                     break;
 
                 default:
-                    availablePlugins.append(card);
+                    availablePlugins.append(listElement);
                     break;
             }
 
-            return card;
+            return listElement;
         }
 
+        // set up filter
         const searchablePlugins = [];
+
+        function shouldHidePlugin(plugin, searchText) {
+            if (plugin.name.includes(searchText)) {
+                return false;
+            }
+            if (plugin.internalName.includes(searchText)) {
+                return false;
+            }
+            if (plugin.author.includes(searchText)) {
+                return false;
+            }
+            if (plugin.punchline?.includes(searchText)) {
+                return false;
+            }
+            if (plugin.description?.includes(searchText)) {
+                return false;
+            }
+            if (plugin.tags?.includes(searchText)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        function filterPlugins(searchText) {
+            const numPluginsVisible = {
+                available: 0,
+                outdated: 0,
+                adoptable: 0,
+                stale: 0,
+                discontinued: 0,
+                obsolete: 0
+            };
+            for (const category of Object.keys(numPluginsVisible)) {
+                document.getElementById(category).classList.remove('hidden');
+            }
+            document.getElementById('no-plugins-found').classList.add('hidden');
+
+            searchablePlugins.forEach((plugin) => {
+                plugin.element.classList.remove('hidden');
+                if (searchText !== '') {
+                    const hide = shouldHidePlugin(plugin.plugin, searchText);
+                    if (hide) {
+                        plugin.element.classList.add('hidden');
+                    } else {
+                        numPluginsVisible[plugin.plugin.type]++;
+                    }
+                } else {
+                    numPluginsVisible[plugin.plugin.type]++;
+                }
+            });
+
+            let someVisible = false;
+            for (const [category, numVisible] of Object.entries(numPluginsVisible)) {
+                if (numVisible === 0) {
+                    document.getElementById(category).classList.add('hidden');
+                } else {
+                    someVisible = true;
+                }
+            }
+            if (!someVisible) {
+                document.getElementById('no-plugins-found').classList.remove('hidden');
+            }
+        }
+
+        document.getElementById('search').value = '';
+        document.getElementById('search').addEventListener('input', (event) => {
+            const searchText = event.target.value.toLowerCase().trim();
+            filterPlugins(searchText);
+        });
+
+
+        // fetch plugins
         fetch(pluginMaster)
             .then((response) => response.json())
             .then(async (json) => {
@@ -254,51 +352,16 @@
                                 author: plugin.Author.toLowerCase(),
                                 punchline: plugin.Punchline?.toLowerCase(),
                                 description: plugin.Description?.toLowerCase(),
-                                tags: plugin.Tags?.join(' ').toLowerCase()
+                                tags: plugin.Tags?.join(' ').toLowerCase(),
+                                type: type?.toLowerCase() ?? 'available'
                             },
                             element: createCard(plugin, type)
                         });
                     });
+
+                // run once to hide empty categories
+                filterPlugins('');
             });
-
-
-        // set up search
-        function shouldHidePlugin(plugin, searchText) {
-            if (plugin.name.includes(searchText)) {
-                return false;
-            }
-            if (plugin.internalName.includes(searchText)) {
-                return false;
-            }
-            if (plugin.author.includes(searchText)) {
-                return false;
-            }
-            if (plugin.punchline?.includes(searchText)) {
-                return false;
-            }
-            if (plugin.description?.includes(searchText)) {
-                return false;
-            }
-            if (plugin.tags?.includes(searchText)) {
-                return false;
-            }
-
-            return true;
-        }
-
-        document.getElementById('search').value = '';
-        document.getElementById('search').addEventListener('input', (event) => {
-            const searchText = event.target.value.toLowerCase().trim();
-            searchablePlugins.forEach((plugin) => {
-                plugin.element.classList.remove('hidden');
-                if (searchText !== '') {
-                    const hide = shouldHidePlugin(plugin.plugin, searchText);
-                    if (hide) {
-                        plugin.element.classList.add('hidden');
-                    }
-                }
-            });
-        });
     </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -139,6 +139,10 @@ p {
     margin: 0.5em 0;
 }
 
+.hidden {
+    display: none !important;
+}
+
 .plugin-list {
     display: flex;
     flex-wrap: wrap;
@@ -152,34 +156,40 @@ p {
     --icon-offset: calc((50px - 1.3rem) / 2);
 
     position: relative;
+    display: flex;
+    flex-direction: row;
     width: calc(50% - 15px);
-    padding: 20px;
     background: var(--plugin-bg);
     clip-path: border-box;
 }
 
+.plugin-list > li > div:first-child {
+    flex: 1;
+    min-width: 0;
+    padding: 20px;
+}
+
+.plugin-list > li > div.testing-indicator {
+    width: 20px;
+    background-image: repeating-linear-gradient(45deg, black, black 15px, #ffc020 16px, #ffc020 30px, black 31px);
+    cursor: help;
+}
+
 /* plugin type "ribbon" */
-.plugin-list > li.ribbon::before {
-    content: attr(data-type);
+div.ribbon {
     position: absolute;
     top: 5px;
     left: 5px;
     width: 150px;
-    height: 25px;
     padding: 2px 0;
     text-align: center;
     font-size: 0.9rem;
     font-weight: bold;
     color: white;
-    background-color: #80e080;
     box-shadow: 0px 2px 3px 0 #0004;
     transform: rotate(-45deg);
     transform-origin: 75px 75px;
     z-index: 20;
-}
-
-.plugin-list > li.hidden {
-    display: none;
 }
 
 .plugin-list header {
@@ -224,7 +234,7 @@ p {
     font-style: italic;
 }
 
-.plugin-list > li > div + div {
+.plugin-list > li > div > div + div {
     margin-top: 10px;
 }
 
@@ -248,31 +258,34 @@ p {
 /**
  * plugin type specific styles
  */
-.plugin-list > li.obsolete::before {
+div.ribbon.obsolete {
     background-color: #5ba3f7;
 }
 
-.plugin-list > li.adoptable::before {
+div.ribbon.adoptable {
     background-color: #61bf5c;
 }
 
-.plugin-list > li.stale::before {
+div.ribbon.stale {
     background-color: #e39b42;
 }
 
-.plugin-list > li.discontinued::before {
+div.ribbon.discontinued {
     background-color: #5ba3f7;
 }
 
-.plugin-list > li.outdated::before {
+div.ribbon.outdated {
     background-color: #e39b42;
 }
 
-.plugin-list > li.banned::before {
+div.ribbon.banned {
     background-color: #da5656;
 }
+div.ribbon.banned[title] {
+    cursor: help;
+}
 
-.plugin-list a.testing::after {
+.testing h3::after {
     content: ' (Testing Exclusive)';
 }
 


### PR DESCRIPTION
Testing exclusive plugins now have a visual indicator (in addition to the label). Ribbons/indicators on banned plugins show their ban reason as a mouseover hint, if available.

Search now hides empty categories and shows a hint when no plugins match the current search criteria.

Fixed a bug where testing exclusive plugins were not labeled as such when they had no repo URL.